### PR TITLE
Include mandatory attribute on queries, fixes #28

### DIFF
--- a/src/System.js
+++ b/src/System.js
@@ -4,6 +4,18 @@
 import Query from "./Query.js";
 
 export class System {
+  canExecute() {
+    if (this._mandatoryQueries.length === 0) return true;
+
+    for (let i = 0; i < this._mandatoryQueries.length; i++) {
+      if (this._mandatoryQueries[i].entities.length === 0) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   toJSON() {
     var json = {
       name: this.constructor.name,
@@ -67,6 +79,8 @@ export class System {
       this.priority = attributes.priority;
     }
 
+    this._mandatoryQueries = [];
+
     this.initialized = true;
 
     this.config = this.init ? this.init() : null;
@@ -82,6 +96,9 @@ export class System {
         var query = this.world.entityManager.queryComponents(Components);
         this._queries[name] = query;
         this.queries[name] = query.entities;
+        if (queryConfig.mandatory === true) {
+          this._mandatoryQueries.push(query);
+        }
 
         if (queryConfig.events) {
           this.events[name] = {};

--- a/src/SystemManager.js
+++ b/src/SystemManager.js
@@ -44,7 +44,7 @@ export class SystemManager {
   execute(delta, time) {
     this.systems.forEach(system => {
       if (system.enabled && system.initialized) {
-        if (system.execute) {
+        if (system.execute && system.canExecute()) {
           let startTime = performance.now();
           system.execute(delta, time);
           system.executeTime = performance.now() - startTime;


### PR DESCRIPTION
Implements https://github.com/fernandojsg/ecsy/issues/28
Some comments:
- The check of this constrains is being done in `canExecute` by the system manager when looping through the systems instead of doing it in the `System.execute` so users don't need to call `super` on every  `execute` implementation. As you are not expected to call `execute` by yourself directly anyway.
- This can be replace in the future, if we feel like implement these: filters https://github.com/fernandojsg/ecsy/issues/31 and a generic `minimum` number of items in order to run `execute` https://github.com/fernandojsg/ecsy/issues/32 but I believe currently this could do the work and just put these two issues on hold until we find the need for them