### PR TITLE
Fix #40 deferred removal/add component cycle issue

### DIFF
--- a/examples/factory/index.html
+++ b/examples/factory/index.html
@@ -105,7 +105,7 @@
         var entity = randomEntity();
         if (!entity) return;
         log(`> Removing name '${entity.getComponent(Name).value}' from player id=${entity.id}`);
-        entity.removeComponent(Name, true);
+        entity.removeComponent(Name);
       });
 
       document.getElementById('removeTshirt').addEventListener('click', () => {
@@ -113,7 +113,7 @@
         if (!entity) return;
         var tshirt = entity.getComponent(Tshirt);
         log(`> Removing '${tshirt.color}' '${tshirt.size}' from player id=${entity.id}`);
-        entity.removeComponent(Tshirt, true);
+        entity.removeComponent(Tshirt);
       });
 
       // Utils

--- a/package-lock.json
+++ b/package-lock.json
@@ -5579,20 +5579,20 @@
       }
     },
     "rollup": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.18.0.tgz",
-      "integrity": "sha512-MBAWr6ectF948gW/bs/yfi0jW7DzwI8n0tEYG/ZMQutmK+blF/Oazyhg3oPqtScCGV8bzCtL9KzlzPtTriEOJA==",
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.19.4.tgz",
+      "integrity": "sha512-G24w409GNj7i/Yam2cQla6qV2k6Nug8bD2DZg9v63QX/cH/dEdbNJg8H4lUm5M1bRpPKRUC465Rm9H51JTKOfQ==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
-        "@types/node": "^12.6.3",
-        "acorn": "^6.2.0"
+        "@types/node": "^12.6.9",
+        "acorn": "^6.2.1"
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.6.9",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
-          "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw==",
+          "version": "12.7.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
+          "integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw==",
           "dev": true
         },
         "acorn": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "eslint-plugin-prettier": "^3.1.0",
     "http-server": "^0.11.1",
     "prettier": "^1.18.2",
-    "rollup": "^1.18.0",
+    "rollup": "^1.19.4",
     "rollup-plugin-json": "^4.0.0"
   }
 }

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -28,11 +28,13 @@ export default class Entity {
     // Instance of the components
     this._components = {};
 
+    this._componentsToRemove = {};
+
     // Queries where the entity is added
     this.queries = [];
 
     // Used for deferred removal
-    this.componentsToRemove = [];
+    this._ComponentTypesToRemove = [];
   }
 
   // COMPONENTS
@@ -49,8 +51,17 @@ export default class Entity {
     return DEBUG ? wrapImmutableComponent(Component, component) : component;
   }
 
+  getRemovedComponent(Component) {
+    return this._componentsToRemove[Component.name];
+  }
+
+
   getComponents() {
     return this._components;
+  }
+
+  getComponentsToRemove() {
+    return this._componentsToRemove;
   }
 
   getComponentTypes() {
@@ -103,8 +114,8 @@ export default class Entity {
    */
   hasComponent(Component, includeRemoved = false) {
     return (
-      !!~this._ComponentTypes.indexOf(Component) &&
-      (includeRemoved || !~this.componentsToRemove.indexOf(Component))
+      !!~this._ComponentTypes.indexOf(Component) ||
+      (includeRemoved && !!~this._ComponentTypesToRemove.indexOf(Component))
     );
   }
 

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -111,11 +111,12 @@ export default class Entity {
    * @param {Component} Component to check
    * @param {Bool} include Components queued for removal (Default is false)
    */
-  hasComponent(Component, includeRemoved = false) {
-    return (
-      !!~this._ComponentTypes.indexOf(Component) ||
-      (includeRemoved && !!~this._ComponentTypesToRemove.indexOf(Component))
-    );
+  hasComponent(Component) {
+    return !!~this._ComponentTypes.indexOf(Component);
+  }
+
+  hasRemovedComponent(Component) {
+    return !!~this._ComponentTypesToRemove.indexOf(Component);
   }
 
   /**

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -55,7 +55,6 @@ export default class Entity {
     return this._componentsToRemove[Component.name];
   }
 
-
   getComponents() {
     return this._components;
   }

--- a/src/EntityManager.js
+++ b/src/EntityManager.js
@@ -140,16 +140,19 @@ export class EntityManager {
     this._queryManager.onEntityRemoved(entity);
 
     if (forceRemove === true) {
-      this._removeEntitySync(entity, index);
+      this._removeEntitySync(entity, index, true);
     } else {
+      this.entityRemoveAllComponents(entity);
       this.entitiesToRemove.push(entity);
     }
   }
 
-  _removeEntitySync(entity, index) {
+  _removeEntitySync(entity, index, removeAllComponents) {
     this._entities.splice(index, 1);
 
-    this.entityRemoveAllComponents(entity, true);
+    if (removeAllComponents) {
+      this.entityRemoveAllComponents(entity, true);
+    }
 
     // Prevent any access and free
     entity._world = null;
@@ -169,7 +172,7 @@ export class EntityManager {
     for (let i = 0; i < this.entitiesToRemove.length; i++) {
       let entity = this.entitiesToRemove[i];
       let index = this._entities.indexOf(entity);
-      this._removeEntitySync(entity, index);
+      this._removeEntitySync(entity, index, false);
     }
     this.entitiesToRemove.length = 0;
 

--- a/src/EntityManager.js
+++ b/src/EntityManager.js
@@ -86,9 +86,16 @@ export class EntityManager {
     if (forceRemove) {
       this._entityRemoveComponentSync(entity, Component, index);
     } else {
-      if (entity.componentsToRemove.length === 0)
+      if (entity._ComponentTypesToRemove.length === 0)
         this.entitiesWithComponentsToRemove.push(entity);
-      entity.componentsToRemove.push(Component);
+
+      entity._ComponentTypes.splice(index, 1);
+      entity._ComponentTypesToRemove.push(Component);
+
+      var componentName = getName(Component);
+      entity._componentsToRemove[componentName] =
+        entity._components[componentName];
+      delete entity._components[componentName];
     }
 
     // Check each indexed query to see if we need to remove it
@@ -168,10 +175,17 @@ export class EntityManager {
 
     for (let i = 0; i < this.entitiesWithComponentsToRemove.length; i++) {
       let entity = this.entitiesWithComponentsToRemove[i];
-      while (entity.componentsToRemove.length > 0) {
-        let Component = entity.componentsToRemove.pop();
-        let index = entity._ComponentTypes.indexOf(Component);
-        this._entityRemoveComponentSync(entity, Component, index);
+      while (entity._ComponentTypesToRemove.length > 0) {
+        let Component = entity._ComponentTypesToRemove.pop();
+
+        var propName = componentPropertyName(Component);
+        var componentName = getName(Component);
+        var component = entity._componentsToRemove[componentName];
+        delete entity._componentsToRemove[componentName];
+        this.componentsManager._componentPool[propName].release(component);
+        //this.world.componentsManager.componentRemovedFromEntity(Component);
+
+        //this._entityRemoveComponentSync(entity, Component, index);
       }
     }
 

--- a/test/unit/entity.test.js
+++ b/test/unit/entity.test.js
@@ -143,11 +143,12 @@ test("removing components deferred", async t => {
   entity.addComponent(FooComponent);
 
   entity.removeComponent(FooComponent); // Deferred remove
-  t.is(entity.getComponentTypes().length, 1);
+  t.is(entity.getComponentTypes().length, 0);
   t.true(entity.hasComponent(FooComponent, true));
   t.false(entity.hasComponent(FooComponent));
   t.false(entity.hasComponent(BarComponent));
-  t.deepEqual(Object.keys(entity.getComponents()), ["FooComponent"]);
+  t.deepEqual(Object.keys(entity.getComponents()), []);
+  t.deepEqual(Object.keys(entity.getComponentsToRemove()), ["FooComponent"]);
 
   world.entityManager.processDeferredRemoval();
   t.is(entity.getComponentTypes().length, 0);

--- a/test/unit/entity.test.js
+++ b/test/unit/entity.test.js
@@ -144,7 +144,8 @@ test("removing components deferred", async t => {
 
   entity.removeComponent(FooComponent); // Deferred remove
   t.is(entity.getComponentTypes().length, 0);
-  t.true(entity.hasComponent(FooComponent, true));
+  t.true(entity.hasRemovedComponent(FooComponent));
+  t.false(entity.hasComponent(FooComponent));
   t.false(entity.hasComponent(FooComponent));
   t.false(entity.hasComponent(BarComponent));
   t.deepEqual(Object.keys(entity.getComponents()), []);

--- a/test/unit/system.test.js
+++ b/test/unit/system.test.js
@@ -502,8 +502,8 @@ test("Queries removing multiple components", t => {
     }
     execute() {
       this.events.entities.removed.forEach(entity => {
-        t.true(entity.hasComponent(FooComponent, true));
-        t.true(entity.hasComponent(BarComponent, true));
+        t.false(entity.hasComponent(FooComponent));
+        t.true(entity.hasRemovedComponent(FooComponent));
       });
 
       // this query should never match
@@ -530,7 +530,6 @@ test("Queries removing multiple components", t => {
   t.is(entitiesA.length, 4);
   t.is(entitiesRemovedA.length, 1);
   systemA.execute();
-
   // Remove second component => It will be the same result
   world.entityManager._entities[1].removeComponent(BarComponent);
   t.is(entitiesA.length, 4);
@@ -550,7 +549,7 @@ test("Queries removing multiple components", t => {
   // Check deferred queues
   t.is(world.entityManager._entities.length, 6);
   t.is(world.entityManager.entitiesToRemove.length, 2);
-  t.is(world.entityManager.entitiesWithComponentsToRemove.length, 2);
+  t.is(world.entityManager.entitiesWithComponentsToRemove.length, 3);
 
   t.is(world.entityManager._entityPool.totalUsed(), 6);
   world.entityManager.processDeferredRemoval();


### PR DESCRIPTION
Fixes #40 
Basically when doing a referred removing of a component, it won't be available on the entity as part of the `getComponent()` call as it's not a "alive" component, so we can prevent people from doing `getMutableComponent` on it and have side effects on other systems.
Instead the component is moved to a `_componentsToRemove` list and it will be cleaned at the end of the frame.
So if we have a `onComponentRemoved` query event list, we will do it this way:
```javascript
this.events.myEntities.removed.forEach(entity => {
  entity.getRemovedComponent(Component) // do whatever with the component
  entity.getComponent(Component) // This will return undefined
});
```

I'm not sure if it's good idea to introduce `getRemovedComponent` or just have a 
```js
getComponent(Component, true /* include removed */)
```

similar to what we do with `hasComponent(Component, includeRemoved?)`