### PR TITLE
Remove singleton functionality

### DIFF
--- a/examples/canvas/index.html
+++ b/examples/canvas/index.html
@@ -22,8 +22,6 @@
       var world = new World();
 
       world
-        .registerSingletonComponent(CanvasContext)
-        .registerSingletonComponent(DemoSettings)
         .registerComponent(Circle)
         .registerComponent(Movement)
         .registerComponent(Intersecting)
@@ -31,11 +29,16 @@
         .registerSystem(Renderer)
         .registerSystem(IntersectionSystem);
 
+      // Used for singleton components
+      world.entity = world.createEntity();
+      world.entity.addComponent(CanvasContext)
+          .addComponent(DemoSettings);
+
       var canvas = document.querySelector("canvas");
       canvas.width = window.innerWidth;
       canvas.height = window.innerHeight;
 
-      var canvasComponent = world.components.canvasContext;
+      var canvasComponent = world.entity.getMutableComponent(CanvasContext);
       canvasComponent.ctx = canvas.getContext("2d");
       canvasComponent.width = canvas.width;
       canvasComponent.height = canvas.height;

--- a/examples/canvas/index.html
+++ b/examples/canvas/index.html
@@ -30,15 +30,15 @@
         .registerSystem(IntersectionSystem);
 
       // Used for singleton components
-      world.entity = world.createEntity();
-      world.entity.addComponent(CanvasContext)
+      var singletonEntity = world.createEntity()
+          .addComponent(CanvasContext)
           .addComponent(DemoSettings);
 
       var canvas = document.querySelector("canvas");
       canvas.width = window.innerWidth;
       canvas.height = window.innerHeight;
 
-      var canvasComponent = world.entity.getMutableComponent(CanvasContext);
+      var canvasComponent = singletonEntity.getMutableComponent(CanvasContext);
       canvasComponent.ctx = canvas.getContext("2d");
       canvasComponent.width = canvas.width;
       canvasComponent.height = canvas.height;

--- a/examples/canvas/systems.js
+++ b/examples/canvas/systems.js
@@ -1,5 +1,11 @@
 import { System } from "../../build/ecsy.module.js";
-import { Movement, Circle, Intersecting } from "./components.js";
+import {
+  CanvasContext,
+  DemoSettings,
+  Movement,
+  Circle,
+  Intersecting
+} from "./components.js";
 import { fillCircle, drawLine, intersection } from "./utils.js";
 
 export class MovementSystem extends System {
@@ -12,9 +18,10 @@ export class MovementSystem extends System {
   }
 
   execute(delta) {
-    let canvasWidth = this.world.components.canvasContext.width;
-    let canvasHeight = this.world.components.canvasContext.height;
-    let multiplier = this.world.components.demoSettings.speedMultiplier;
+    let canvasWidth = this.world.entity.getComponent(CanvasContext).width;
+    let canvasHeight = this.world.entity.getComponent(CanvasContext).height;
+    let multiplier = this.world.entity.getComponent(DemoSettings)
+      .speedMultiplier;
 
     let entities = this.queries.entities;
     for (var i = 0; i < entities.length; i++) {
@@ -117,7 +124,7 @@ export class Renderer extends System {
   }
 
   execute() {
-    let canvasComponent = this.world.components.canvasContext;
+    let canvasComponent = this.world.entity.getComponent(CanvasContext);
     let ctx = canvasComponent.ctx;
     let canvasWidth = canvasComponent.width;
     let canvasHeight = canvasComponent.height;

--- a/examples/canvas/systems.js
+++ b/examples/canvas/systems.js
@@ -12,16 +12,17 @@ export class MovementSystem extends System {
   init() {
     return {
       queries: {
-        entities: { components: [Circle, Movement] }
+        entities: { components: [Circle, Movement] },
+        context: { components: [CanvasContext, DemoSettings], mandatory: true }
       }
     };
   }
 
   execute(delta) {
-    let canvasWidth = this.world.entity.getComponent(CanvasContext).width;
-    let canvasHeight = this.world.entity.getComponent(CanvasContext).height;
-    let multiplier = this.world.entity.getComponent(DemoSettings)
-      .speedMultiplier;
+    var context = this.queries.context[0];
+    let canvasWidth = context.getComponent(CanvasContext).width;
+    let canvasHeight = context.getComponent(CanvasContext).height;
+    let multiplier = context.getComponent(DemoSettings).speedMultiplier;
 
     let entities = this.queries.entities;
     for (var i = 0; i < entities.length; i++) {
@@ -118,13 +119,15 @@ export class Renderer extends System {
     return {
       queries: {
         circles: { components: [Circle] },
-        intersectingCircles: { components: [Intersecting] }
+        intersectingCircles: { components: [Intersecting] },
+        context: { components: [CanvasContext], mandatory: true }
       }
     };
   }
 
   execute() {
-    let canvasComponent = this.world.entity.getComponent(CanvasContext);
+    var context = this.queries.context[0];
+    let canvasComponent = context.getComponent(CanvasContext);
     let ctx = canvasComponent.ctx;
     let canvasWidth = canvasComponent.width;
     let canvasHeight = canvasComponent.height;

--- a/examples/norender/index.html
+++ b/examples/norender/index.html
@@ -120,8 +120,8 @@
         .registerSystem(MyNot);
 
       // Used for singleton components
-      world.entity = world.createEntity();
-      world.entity.addComponent(InputState);
+      var singletonEntity = world.createEntity();
+      singletonEntity.addComponent(InputState);
 
       for (var i = 0; i < 10; i++) {
         var entity = world.createEntity();

--- a/examples/norender/index.html
+++ b/examples/norender/index.html
@@ -116,9 +116,12 @@
         .registerComponent(Rotating)
         .registerComponent(Pulsating)
         .registerComponent(Transform)
-        .registerSingletonComponent(InputState)
         .registerSystem(MyReactiveSystem)
         .registerSystem(MyNot);
+
+      // Used for singleton components
+      world.entity = world.createEntity();
+      world.entity.addComponent(InputState);
 
       for (var i = 0; i < 10; i++) {
         var entity = world.createEntity();

--- a/ideas.md
+++ b/ideas.md
@@ -1,7 +1,0 @@
-Events:
-- Add 'alive' attribute on components?
-- Limit number of components to 1 on events/queries
-- What to do with the Group/Mesh/Object3D if several systems wants to share the same entity
-- onEvent attribute on a component to be used for example to trigger the paint/teleport action, how to define it
-- this.component inside systems
-- Component that doesn't need reset() but want to benefit from Pool? => nop

--- a/src/ComponentManager.js
+++ b/src/ComponentManager.js
@@ -8,7 +8,6 @@ import { componentPropertyName } from "./Utils.js";
 export class ComponentManager {
   constructor() {
     this.Components = {};
-    this.SingletonComponents = {};
     this._componentPool = {};
     this.numComponents = {};
   }
@@ -20,14 +19,6 @@ export class ComponentManager {
   registerComponent(Component) {
     this.Components[Component.name] = Component;
     this.numComponents[Component.name] = 0;
-  }
-
-  /**
-   * Register a singleton component
-   * @param {Component} Component Component to register as singleton
-   */
-  registerSingletonComponent(Component) {
-    this.SingletonComponents[Component.name] = Component;
   }
 
   componentAddedToEntity(Component) {

--- a/src/Query.js
+++ b/src/Query.js
@@ -27,6 +27,7 @@ export default class Query {
     this.single = single === true;
 
     this.entities = [];
+    this.entity = null;
 
     this.eventDispatcher = new EventDispatcher();
 

--- a/src/System.js
+++ b/src/System.js
@@ -8,7 +8,11 @@ export class System {
     if (this._mandatoryQueries.length === 0) return true;
 
     for (let i = 0; i < this._mandatoryQueries.length; i++) {
-      if (this._mandatoryQueries[i].entities.length === 0) {
+      var query = this._mandatoryQueries[i];
+      if (
+        (query.single && query.entity === null) ||
+        (!query.single && query.entities.length === 0)
+      ) {
         return false;
       }
     }

--- a/src/World.js
+++ b/src/World.js
@@ -1,7 +1,6 @@
 import { SystemManager } from "./SystemManager.js";
 import { EntityManager } from "./EntityManager.js";
 import { ComponentManager } from "./ComponentManager.js";
-import { componentPropertyName } from "./Utils.js";
 import EventDispatcher from "./EventDispatcher.js";
 
 /**
@@ -14,9 +13,6 @@ export class World {
     this.systemManager = new SystemManager(this);
 
     this.enabled = true;
-
-    // Storage for singleton components
-    this.components = {};
 
     this.eventQueues = {};
     this.eventDispatcher = new EventDispatcher();
@@ -37,16 +33,6 @@ export class World {
 
   removeEventListener(eventName, callback) {
     this.eventDispatcher.removeEventListener(eventName, callback);
-  }
-
-  /**
-   * Register a singleton component
-   * @param {Component} Component Singleton component
-   */
-  registerSingletonComponent(Component) {
-    this.componentsManager.registerSingletonComponent(Component);
-    this.components[componentPropertyName(Component)] = new Component();
-    return this;
   }
 
   /**


### PR DESCRIPTION
Removing singleton functionality without using queries at all, just accessing the entity we created attached to `world.entity` (just for the sake of taking advantage of having world instance on the system, but it could be defined somewhere else).
In any case we agreed that singleton as it's implemented currently should change in this direction.
We could decide later if to include helper functions as in https://github.com/fernandojsg/ecsy/pull/39 as I expect this pattern to be used a lot