### PR TITLE
Remove `single` functionality

### DIFF
--- a/src/EntityManager.js
+++ b/src/EntityManager.js
@@ -182,8 +182,8 @@ export class EntityManager {
    * Get a query based on a list of components
    * @param {Array(Component)} Components List of components that will form the query
    */
-  queryComponents(Components, single) {
-    return this._queryManager.getQuery(Components, single);
+  queryComponents(Components) {
+    return this._queryManager.getQuery(Components);
   }
 
   // EXTRAS

--- a/src/Query.js
+++ b/src/Query.js
@@ -8,7 +8,7 @@ export default class Query {
   /**
    * @param {Array(Component)} Components List of types of components to query
    */
-  constructor(Components, manager, single) {
+  constructor(Components, manager) {
     this.Components = [];
     this.NotComponents = [];
 
@@ -24,10 +24,7 @@ export default class Query {
       throw new Error("Can't create a query without components");
     }
 
-    this.single = single === true;
-
     this.entities = [];
-    this.entity = null;
 
     this.eventDispatcher = new EventDispatcher();
 
@@ -41,10 +38,6 @@ export default class Query {
       var entity = manager._entities[i];
       if (this.match(entity)) {
         // @todo ??? this.addEntity(entity); => preventing the event to be generated
-        if (this.single) {
-          this.entity = entity;
-          return;
-        }
         entity.queries.push(this);
         this.entities.push(entity);
       }
@@ -57,11 +50,7 @@ export default class Query {
    */
   addEntity(entity) {
     entity.queries.push(this);
-    if (this.single) {
-      this.entity = entity;
-    } else {
-      this.entities.push(entity);
-    }
+    this.entities.push(entity);
 
     this.eventDispatcher.dispatchEvent(Query.prototype.ENTITY_ADDED, entity);
   }
@@ -71,31 +60,17 @@ export default class Query {
    * @param {Entity} entity
    */
   removeEntity(entity) {
-    if (this.single) {
-      // @todo Check ID?
-      if (this.entity === entity) {
-        this.entity = null;
-        let index = entity.queries.indexOf(this);
-        entity.queries.splice(index, 1);
+    let index = this.entities.indexOf(entity);
+    if (~index) {
+      this.entities.splice(index, 1);
 
-        this.eventDispatcher.dispatchEvent(
-          Query.prototype.ENTITY_REMOVED,
-          entity
-        );
-      }
-    } else {
-      let index = this.entities.indexOf(entity);
-      if (~index) {
-        this.entities.splice(index, 1);
+      index = entity.queries.indexOf(this);
+      entity.queries.splice(index, 1);
 
-        index = entity.queries.indexOf(this);
-        entity.queries.splice(index, 1);
-
-        this.eventDispatcher.dispatchEvent(
-          Query.prototype.ENTITY_REMOVED,
-          entity
-        );
-      }
+      this.eventDispatcher.dispatchEvent(
+        Query.prototype.ENTITY_REMOVED,
+        entity
+      );
     }
   }
 

--- a/src/QueryManager.js
+++ b/src/QueryManager.js
@@ -89,11 +89,11 @@ export default class QueryManager {
    * Get a query for the specified components
    * @param {Component} Components Components that the query should have
    */
-  getQuery(Components, single) {
-    var key = queryKey(Components) + (single === true ? "-single" : "");
+  getQuery(Components) {
+    var key = queryKey(Components);
     var query = this._queries[key];
     if (!query) {
-      this._queries[key] = query = new Query(Components, this._world, single);
+      this._queries[key] = query = new Query(Components, this._world);
     }
     return query;
   }

--- a/src/System.js
+++ b/src/System.js
@@ -9,10 +9,7 @@ export class System {
 
     for (let i = 0; i < this._mandatoryQueries.length; i++) {
       var query = this._mandatoryQueries[i];
-      if (
-        (query.single && query.entity === null) ||
-        (!query.single && query.entities.length === 0)
-      ) {
+      if (query.entities.length === 0) {
         return false;
       }
     }
@@ -54,16 +51,12 @@ export class System {
         if (!Components || Components.length === 0) {
           throw new Error("'components' attribute can't be empty in a query");
         }
-        var query = this.world.entityManager.queryComponents(
-          Components,
-          queryConfig.single === true
-        );
+        var query = this.world.entityManager.queryComponents(Components);
         this._queries[name] = query;
         if (queryConfig.mandatory === true) {
           this._mandatoryQueries.push(query);
         }
-        this.queries[name] =
-          queryConfig.single === true ? query.entity : query.entities;
+        this.queries[name] = query.entities;
 
         if (queryConfig.events) {
           this.events[name] = {};

--- a/test/unit/system.test.js
+++ b/test/unit/system.test.js
@@ -898,35 +898,3 @@ test("Queries with 'mandatory' parameter", t => {
   world.execute();
   t.deepEqual(counter, { a: 4, b: 2, c: 2 });
 });
-
-test("Query single", t => {
-  var world = new World();
-
-  world
-    .registerComponent(FooComponent)
-    .registerComponent(BarComponent)
-    .registerComponent(EmptyComponent);
-
-  var entity = world.createEntity();
-  entity.addComponent(FooComponent).addComponent(BarComponent);
-
-  class SystemA extends System {
-    init() {
-      return {
-        queries: {
-          entity: {
-            components: [FooComponent, BarComponent],
-            single: true
-          }
-        }
-      };
-    }
-  }
-
-  world.registerSystem(SystemA);
-
-  var systemA = world.systemManager.systems[0];
-
-  // Remove one entity => entityRemoved x1
-  t.is(systemA.queries.entity, entity);
-});


### PR DESCRIPTION
Because it's currently broken because of the references from `system.queries[].entity = query.entity`